### PR TITLE
change namespace from coqart89 to just coqart

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make install
 ```
 
 After installation, the included modules are available under
-the `coqart89` namespace.
+the `coqart` namespace.
 
 
 ## Documentation

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
--R . coqart89
+-R . coqart
 ./ch9_function_specification/SRC/fib_positive.v
 ./ch9_function_specification/SRC/fib_ind.v
 ./ch9_function_specification/SRC/extract.v

--- a/coq-coq-art.opam
+++ b/coq-coq-art.opam
@@ -24,7 +24,7 @@ depends: [
 tags: [
   "category:Miscellaneous/Coq Use Examples"
   "keyword:calculus of constructions"
-  "logpath:coqart89"
+  "logpath:coqart"
 ]
 authors: [
   "Yves Bertot"

--- a/meta.yml
+++ b/meta.yml
@@ -43,7 +43,7 @@ tested_coq_nix_versions:
 tested_coq_opam_versions:
 - version: 8.9
 
-namespace: coqart89
+namespace: coqart
 
 keywords:
 - name: calculus of constructions


### PR DESCRIPTION
To ease evolution a bit, I propose to change the namespace to simply `coqart`. Since every Coq version is assumed to have its own Coq-Art code release, and its own `user-contrib`, I don't see a reason to have different namespaces for each release.