### PR TITLE
change license in metadata as per LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ out of over 200 exercises from the book.
 - Coq-community maintainer(s):
   - Yves Bertot ([**@ybertot**](https://github.com/ybertot))
   - Pierre Castéran ([**@Casteran**](https://github.com/Casteran))
-- License: [CeCILL-B](LICENSE)
+- License: [MIT License](LICENSE)
 - Compatible Coq versions: 8.10 or later (use the corresponding release for other Coq versions)
 - Additional dependencies: none
 - Coq namespace: `coqart`

--- a/coq-coq-art.opam
+++ b/coq-coq-art.opam
@@ -5,7 +5,7 @@ version: "dev"
 homepage: "https://github.com/coq-community/coq-art"
 dev-repo: "git+https://github.com/coq-community/coq-art.git"
 bug-reports: "https://github.com/coq-community/coq-art/issues"
-license: "CECILL-B"
+license: "MIT"
 
 synopsis: "Coq sources and exercises from the Coq'Art book"
 description: """
@@ -14,7 +14,7 @@ and its underlying theory, the Calculus of Inductive Constructions.
 This project contains the Coq sources of all examples and the solution to 170
 out of over 200 exercises from the book."""
 
-build: [make "-j%{jobs}%"]
+build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {>= "8.10" & < "8.13~"}

--- a/meta.yml
+++ b/meta.yml
@@ -36,8 +36,8 @@ opam-file-maintainer: palmskog@gmail.com
 opam-file-version: dev
 
 license:
-  fullname: CeCILL-B
-  identifier: CECILL-B
+  fullname: MIT License
+  identifier: MIT
 
 supported_coq_versions:
   text: 8.10 or later (use the corresponding release for other Coq versions)


### PR DESCRIPTION
@Casteran this update concludes the switch to the MIT license for the coq-art repo.