### PR TITLE
typo of `cond_rewrite_example`

### DIFF
--- a/ch5_everydays_logic/SRC/chap5.v
+++ b/ch5_everydays_logic/SRC/chap5.v
@@ -239,7 +239,7 @@ Qed.
 *)
 
 Lemma conditional_rewrite_example' : forall n:nat,
-   8 < n + 6 ->  3 + n < 6 -> n * n = n + n.
+   8 <= n + 6 ->  3 + n < 6 -> n * n = n + n.
 Proof.
  intros n  H H0.
  assert (n = 2) by omega.


### PR DESCRIPTION
Is the first `<` of the statement of `cond_rewrite_example` a mistake for `<=`?

Since these premises lead to contradictions, any consequence can be proved. For example:
```coq
Goal : forall n:nat, 8 < n+6 ->  3+n < 6 -> 0 = 1.
Proof.
  intros. omega.
Qed.
```