### PR TITLE
fix two typos in explanations, change the date and author mail address

### DIFF
--- a/ch15_general_recursion/sqrt_nat_wf.html
+++ b/ch15_general_recursion/sqrt_nat_wf.html
@@ -8,12 +8,11 @@
     <h1>Computing square roots (with well-founded recursion)</h1>
 <p>Given a natural number <i>x</i>, we want to compute the pair of numbers
 <i>s</i> and <i>r</i> such that <i>s * s &le; x &lt; (S+1)*(s+1)</i>
-and <i>x=s*s+r</i>.</p>.  Let <i>x=4*q+r0</i> with <i>r&lt;4</i>.  If <i>s'</i>
+and <i>x=s*s+r</i>.</p>.  Let <i>x=4*q+r0</i> with <i>r0&lt;4</i>.  If <i>s'</i>
  and <i>r'</i> are the result for computing the square root of <i>q</i>, then there
 are two possibilities:
 <ol>
-<li>If <i>4*r'+r0 &lt;4*s'+1</i> then
- either <i>s=2s'</i> and <i>r=4r'+r0</i></li>
+<li>If <i>4*r'+r0 &lt;4*s'+1</i> then <i>s=2s'</i> and <i>r=4r'+r0</i></li>
 <li>Otherwise <i>s=2s'+1</i> and <i>r=r4'+r0-4s'-1</i>
 </ol>
 Build a function that uses this algorithm to
@@ -31,8 +30,8 @@ sqrt_nat : forall n:nat,
 <br><br>
 <hr>
     <hr>
-    <address><a href="mailto:bertot@harfang.inria.fr">Yves Bertot</a></address>
+    <address><a href="mailto:bertot@inria.fr">Yves Bertot</a></address>
 <!-- Created: Mon May 12 20:36:11 MEST 2003 -->
-<!-- hhmts start -->Last modified: Tue Jul 19 17:23:19 CEST 2022 <!-- hhmts end -->
+<!-- hhmts start -->Last modified: Tue Jul 20 17:30:00 CEST 2022 <!-- hhmts end -->
   </body>
 </html>


### PR DESCRIPTION
There was work on this page yesterday, but when looking at the exercise statement I noticed mistakes (which I probably introduced in the first place).