### PR TITLE
Prepare 8.15 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ Makefile.coq
 Makefile.coq.conf
 execute_loops.ml
 execute_loops.mli
-insert-sort.ml
-insert-sort.mli
+insert_sort.ml
+insert_sort.mli
 pplus.ml
 pplus.mli
 .lia.cache

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,0 +1,2 @@
+clean::
+	$(HIDE)rm -f execute_loops.ml execute_loops.mli insert_sort.ml insert_sort.mli pplus.ml pplus.mli

--- a/ch14_fundations_of_inductive_types/SRC/chap14.v
+++ b/ch14_fundations_of_inductive_types/SRC/chap14.v
@@ -322,8 +322,6 @@ Scheme ntree_ind2 :=
    Induction for ntree Sort Prop
  with nforest_ind2 :=
    Induction for nforest Sort Prop.
-Arguments ntree_ind2 A P P0 : rename.
-Arguments nforest_ind2 A P P0 : rename.
 
 Inductive occurs (A:Type)(a:A) : ntree A -> Prop :=
 | occurs_root : forall l, occurs A a (nnode A a l)

--- a/ch14_fundations_of_inductive_types/SRC/ltree_to_ntree.v
+++ b/ch14_fundations_of_inductive_types/SRC/ltree_to_ntree.v
@@ -13,8 +13,6 @@ Scheme
 ntree_ind2 := Induction for ntree Sort Prop
    with
    nforest_ind2 := Induction for nforest Sort Prop.
-Arguments ntree_ind2 A P P0 : rename.
-Arguments nforest_ind2 A P P0 : rename.
  
 Section correct_ltree_ind.
 Variables (A : Type) (P : ltree A ->  Prop) (Q : list (ltree A) ->  Prop).

--- a/ch1_overview/SRC/chap1.v
+++ b/ch1_overview/SRC/chap1.v
@@ -154,6 +154,4 @@ Definition sort :
     +  now apply insert_sorted. 
 Defined.
 
-Extraction "insert-sort" insert sort.
-
-
+Extraction "insert_sort" insert sort.

--- a/tutorial_inductive_co_inductive_types/SRC/RecTutorial.v
+++ b/tutorial_inductive_co_inductive_types/SRC/RecTutorial.v
@@ -671,8 +671,6 @@ End Principle_of_Induction.
 
 Scheme Even_induction := Minimality for even Sort Prop
 with   Odd_induction  := Minimality for odd  Sort Prop.
-Arguments Even_induction P P0 : rename.
-Arguments Odd_induction P P0 : rename.
 
 Theorem even_plus_four : forall n:nat, even n -> even (4+n).
 Proof.


### PR DESCRIPTION
Let's avoid `Argument` after `Scheme` if we don't need it.